### PR TITLE
Add dark mode (system preference)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
     <link rel="icon" href="/timer/bee.svg" sizes="any" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/timer/apple-touch-icon-180x180.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="theme-color" content="#4c2e68" />
+    <meta name="theme-color" content="#4c2e68" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1a1a2e" media="(prefers-color-scheme: dark)" />
     <title>Beeminder Timer</title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -265,6 +265,56 @@ select {
   border-radius: 4px;
 }
 
+/* === Dark Mode (follows system preference) === */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bee-yellow: #ffcc00;
+    --bee-purple: #9b7cc8;
+    --bee-purple-dark: #c4a6e8;
+    --bee-black: #e8e8e8;
+    --bee-bg: #1a1a2e;
+    --panel-bg: #252540;
+    --panel-border: #3d3a50;
+  }
+
+  input,
+  select {
+    background: #2d2b45;
+  }
+
+  input:focus,
+  select:focus {
+    box-shadow: 0 0 0 2px rgba(155, 124, 200, 0.3);
+  }
+
+  select {
+    background-image: url("data:image/svg+xml;utf8,<svg fill='%239b7cc8' height='20' width='20' viewBox='0 0 20 20'><polygon points='5,7 15,7 10,14'/></svg>");
+  }
+
+  .btn-secondary:hover {
+    background: #8b6bba;
+  }
+  .btn-secondary:active {
+    background: #6a4f96;
+  }
+
+  .btn-reset {
+    background: #3d3a50;
+  }
+  .btn-reset:hover {
+    background: #4a4760;
+  }
+  .btn-reset:active {
+    background: #333050;
+  }
+
+  .error-text {
+    color: #ff8a80;
+    background-color: #3c1f1f;
+    border-color: #ff5252;
+  }
+}
+
 /* === Mobile === */
 @media (max-width: 640px) {
   body {


### PR DESCRIPTION
## Summary
- Adds CSS-only dark mode via `@media (prefers-color-scheme: dark)` — automatically follows the OS setting, no JS toggle or localStorage needed
- Overrides `:root` CSS custom properties with dark-appropriate colors (lighter purples for contrast, dark backgrounds/panels/borders, light text)
- Overrides hardcoded colors for inputs, buttons, error states, and the select dropdown arrow
- Splits the `theme-color` meta tag into light/dark variants so browser chrome matches

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` is clean
- [x] Toggle system dark mode on desktop — app switches appearance
- [x] Check on iPhone PWA — browser chrome color matches dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)