### PR TITLE
Add notification sound volume control

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -275,6 +275,60 @@ select:focus {
   border-radius: 4px;
 }
 
+/* === Volume Control === */
+.volume-control {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+}
+
+.volume-label {
+  min-width: 3.5rem;
+  font-size: 0.9rem;
+  color: var(--bee-black);
+  opacity: 0.75;
+}
+
+input[type="range"] {
+  appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: var(--panel-border);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+input[type="range"]:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(106 76 147 / 20%);
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--bee-purple);
+  border: 2px solid #fff;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+  cursor: pointer;
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--bee-purple);
+  border: 2px solid #fff;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+  cursor: pointer;
+}
+
 /* === Dark Mode === */
 [data-theme="dark"] {
   --bee-yellow: #fc0;
@@ -293,6 +347,18 @@ select:focus {
 
 [data-theme="dark"] select {
   background-image: url("data:image/svg+xml;utf8,<svg fill='%239b7cc8' height='20' width='20' viewBox='0 0 20 20'><polygon points='5,7 15,7 10,14'/></svg>");
+}
+
+[data-theme="dark"] input[type="range"] {
+  background: #3d3a50;
+}
+
+[data-theme="dark"] input[type="range"]::-webkit-slider-thumb {
+  border-color: #252540;
+}
+
+[data-theme="dark"] input[type="range"]::-moz-range-thumb {
+  border-color: #252540;
 }
 
 [data-theme="dark"] input:focus,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { useBeeminder } from "./hooks/useBeeminder.ts";
 import { useTimer, loadPersistedTimerState } from "./hooks/useTimer.ts";
 import { useOfflineQueue } from "./hooks/useOfflineQueue.ts";
 import { useTheme } from "./hooks/useTheme.ts";
+import { useVolume } from "./hooks/useVolume.ts";
 
 const App: React.FC = () => {
   const [persistedTimer] = useState(loadPersistedTimerState);
@@ -17,6 +18,7 @@ const App: React.FC = () => {
   const [youtubeTitle, setYoutubeTitle] = useState<string | null>(null);
 
   const { themePreference, setThemePreference } = useTheme();
+  const { volume, setVolume } = useVolume();
 
   const settings = useSettings();
   const { username, authToken } = settings;
@@ -81,6 +83,7 @@ const App: React.FC = () => {
     username,
     authToken,
     comment,
+    volume,
     onComplete,
     onFlush,
   });
@@ -320,6 +323,23 @@ const App: React.FC = () => {
             <option value="light">Light</option>
             <option value="dark">Dark</option>
           </select>
+        </label>
+
+        <label>
+          <b>Volume</b>
+          <div className="volume-control">
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              value={volume}
+              onChange={(e) => setVolume(parseFloat(e.target.value))}
+            />
+            <span className="volume-label">
+              {volume === 0 ? "Muted" : `${Math.round(volume * 100)}%`}
+            </span>
+          </div>
         </label>
       </section>
     </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,4 +10,6 @@ export const OFFLINE_QUEUE_KEY = "beeminderTimerOfflineQueue";
 
 export const THEME_KEY = "beeminderTimerTheme";
 
+export const VOLUME_KEY = "beeminderTimerVolume";
+
 export const durations = [5, 10, 15, 20, 30, 45, 60]; // minutes

--- a/src/hooks/useTimer.test.ts
+++ b/src/hooks/useTimer.test.ts
@@ -25,6 +25,7 @@ function makeOptions(overrides: Partial<Parameters<typeof useTimer>[0]> = {}) {
     username: "testuser",
     authToken: "testtoken",
     comment: "",
+    volume: 0.7,
     onComplete: vi.fn().mockResolvedValue(undefined),
     onFlush: vi.fn().mockResolvedValue(undefined),
     ...overrides,

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -4,7 +4,6 @@ import { TIMER_STATE_KEY } from "../constants.ts";
 import { formatTime } from "../utils.ts";
 
 const ding = new Audio("notification.mp3");
-ding.volume = 0.7;
 
 export function loadPersistedTimerState(): StoredTimerState | null {
   try {
@@ -22,6 +21,7 @@ type UseTimerOptions = {
   username: string;
   authToken: string;
   comment: string;
+  volume: number;
   onComplete: () => Promise<void>;
   onFlush: (elapsed: number) => Promise<void>;
 };
@@ -32,6 +32,7 @@ export function useTimer({
   username,
   authToken,
   comment,
+  volume,
   onComplete,
   onFlush,
 }: UseTimerOptions) {
@@ -105,6 +106,7 @@ export function useTimer({
         await onComplete();
 
         try {
+          ding.volume = volume;
           ding.currentTime = 0;
           void ding.play();
         } catch {
@@ -242,6 +244,7 @@ export function useTimer({
       await onFlush(elapsed);
 
       try {
+        ding.volume = volume;
         ding.currentTime = 0;
         void ding.play();
       } catch {
@@ -269,7 +272,15 @@ export function useTimer({
       setStatus("error");
       setError((e as Error).message);
     }
-  }, [remaining, selectedDuration, username, authToken, goalSlug, onFlush]);
+  }, [
+    remaining,
+    selectedDuration,
+    username,
+    authToken,
+    goalSlug,
+    volume,
+    onFlush,
+  ]);
 
   // Keyboard shortcut for space bar
   useEffect(() => {

--- a/src/hooks/useVolume.ts
+++ b/src/hooks/useVolume.ts
@@ -1,0 +1,23 @@
+import { useState, useCallback } from "react";
+import { VOLUME_KEY } from "../constants.ts";
+
+function loadVolume(): number {
+  const stored = localStorage.getItem(VOLUME_KEY);
+  if (stored !== null) {
+    const parsed = parseFloat(stored);
+    if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) return parsed;
+  }
+  return 0.7;
+}
+
+export function useVolume() {
+  const [volume, setVolumeState] = useState<number>(loadVolume);
+
+  const setVolume = useCallback((value: number) => {
+    const clamped = Math.max(0, Math.min(1, value));
+    localStorage.setItem(VOLUME_KEY, String(clamped));
+    setVolumeState(clamped);
+  }, []);
+
+  return { volume, setVolume };
+}


### PR DESCRIPTION
## Summary

- Add a volume slider (0–100%) to the settings panel below the Theme selector, persisted to localStorage
- Create `useVolume` hook following the existing `useTheme` pattern with its own storage key
- Replace hardcoded `0.7` volume with a user-configurable value applied before each `ding.play()` call
- Style the range input to match the app's purple palette, including dark mode

## Test plan

- [x] `npm run build` passes with no type errors
- [x] `npm run lint` passes with no lint errors
- [x] All 51 existing tests pass
- [x] Manual: open dev server, drag slider, confirm volume changes on next notification
- [x] Manual: set to 0%, confirm "Muted" label appears and no sound plays
- [x] Manual: reload page, confirm slider retains its position

🤖 Generated with [Claude Code](https://claude.com/claude-code)