### PR TITLE
Add toggle buttons for auto-renew and pomodoro mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -150,7 +150,7 @@ select:focus {
 .btn-toggle {
   background: transparent;
   color: var(--bee-purple);
-  border: 2px solid var(--panel-border);
+  border: 2px solid var(--bee-purple);
   box-shadow: none;
   padding: 0.5rem 0.8rem;
   font-size: 1.1rem;

--- a/src/App.css
+++ b/src/App.css
@@ -139,15 +139,60 @@ select:focus {
   opacity: 0.75;
 }
 
-/* === Checkbox Labels (inline) === */
-.auto-renew-label {
+/* === Toggle Buttons === */
+.toggle-buttons {
   display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 0.7rem;
 }
 
-.auto-renew-label input[type="checkbox"] {
-  width: auto;
+.btn-toggle {
+  background: var(--bee-purple-dark);
+  color: rgb(255 255 255 / 60%);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 15%);
+  padding: 0.5rem 0.8rem;
+  font-size: 1.1rem;
+}
+
+.btn-toggle:hover {
+  background: #5a3580;
+}
+
+.btn-toggle.active {
+  background: #e8daf5;
+  color: var(--bee-purple);
+  border: 2px solid var(--bee-purple);
+}
+
+.btn-toggle.active:hover {
+  background: #dccbee;
+}
+
+[data-theme="dark"] .btn-toggle {
+  background: #2d2b45;
+  color: rgb(255 255 255 / 40%);
+}
+
+[data-theme="dark"] .btn-toggle:hover {
+  background: #3d3a55;
+}
+
+[data-theme="dark"] .btn-toggle.active {
+  background: #3d3560;
+  color: #c4a6e8;
+  border-color: #9b7cc8;
+}
+
+[data-theme="dark"] .btn-toggle.active:hover {
+  background: #4a4070;
+}
+
+.break-indicator {
+  font-size: 0.95rem;
+  color: var(--bee-purple);
+  font-weight: 600;
+  margin-bottom: 0.5rem;
 }
 
 /* === Progress Ring === */

--- a/src/App.css
+++ b/src/App.css
@@ -148,25 +148,27 @@ select:focus {
 }
 
 .btn-toggle {
-  background: #8b6bba;
-  color: rgb(255 255 255 / 85%);
-  box-shadow: 0 2px 6px rgb(106 76 147 / 30%);
+  background: transparent;
+  color: var(--bee-purple);
+  border: 2px solid var(--panel-border);
+  box-shadow: none;
   padding: 0.5rem 0.8rem;
   font-size: 1.1rem;
 }
 
 .btn-toggle:hover {
-  background: #9b7cc8;
+  background: #f0e6fa;
 }
 
 .btn-toggle.active {
-  background: #f0e6fa;
-  color: var(--bee-purple);
+  background: var(--bee-purple);
+  color: #fff;
   border: 2px solid var(--bee-purple);
+  box-shadow: 0 2px 6px rgb(106 76 147 / 30%);
 }
 
 .btn-toggle.active:hover {
-  background: #e4d4f4;
+  background: #7b5baa;
 }
 
 [data-theme="dark"] .btn-toggle {

--- a/src/App.css
+++ b/src/App.css
@@ -148,40 +148,40 @@ select:focus {
 }
 
 .btn-toggle {
-  background: var(--bee-purple-dark);
-  color: rgb(255 255 255 / 60%);
-  box-shadow: 0 2px 6px rgb(0 0 0 / 15%);
+  background: #8b6bba;
+  color: rgb(255 255 255 / 85%);
+  box-shadow: 0 2px 6px rgb(106 76 147 / 30%);
   padding: 0.5rem 0.8rem;
   font-size: 1.1rem;
 }
 
 .btn-toggle:hover {
-  background: #5a3580;
+  background: #9b7cc8;
 }
 
 .btn-toggle.active {
-  background: #e8daf5;
+  background: #f0e6fa;
   color: var(--bee-purple);
   border: 2px solid var(--bee-purple);
 }
 
 .btn-toggle.active:hover {
-  background: #dccbee;
+  background: #e4d4f4;
 }
 
 [data-theme="dark"] .btn-toggle {
-  background: #2d2b45;
-  color: rgb(255 255 255 / 40%);
+  background: #4a4070;
+  color: rgb(255 255 255 / 75%);
 }
 
 [data-theme="dark"] .btn-toggle:hover {
-  background: #3d3a55;
+  background: #5a4f80;
 }
 
 [data-theme="dark"] .btn-toggle.active {
-  background: #3d3560;
-  color: #c4a6e8;
-  border-color: #9b7cc8;
+  background: #5a3d8a;
+  color: #dbc4f5;
+  border-color: #b89ee0;
 }
 
 [data-theme="dark"] .btn-toggle.active:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -147,7 +147,7 @@ select:focus {
   margin-bottom: 0.7rem;
 }
 
-.btn-toggle {
+.btn.btn-toggle {
   background: transparent;
   color: var(--bee-purple);
   border: 2px solid var(--bee-purple);
@@ -156,37 +156,38 @@ select:focus {
   font-size: 1.1rem;
 }
 
-.btn-toggle:hover {
+.btn.btn-toggle:hover {
   background: #f0e6fa;
 }
 
-.btn-toggle.active {
+.btn.btn-toggle.active {
   background: var(--bee-purple);
   color: #fff;
   border: 2px solid var(--bee-purple);
   box-shadow: 0 2px 6px rgb(106 76 147 / 30%);
 }
 
-.btn-toggle.active:hover {
+.btn.btn-toggle.active:hover {
   background: #7b5baa;
 }
 
-[data-theme="dark"] .btn-toggle {
+[data-theme="dark"] .btn.btn-toggle {
   background: #4a4070;
   color: rgb(255 255 255 / 75%);
+  border-color: #9b7cc8;
 }
 
-[data-theme="dark"] .btn-toggle:hover {
+[data-theme="dark"] .btn.btn-toggle:hover {
   background: #5a4f80;
 }
 
-[data-theme="dark"] .btn-toggle.active {
+[data-theme="dark"] .btn.btn-toggle.active {
   background: #5a3d8a;
   color: #dbc4f5;
   border-color: #b89ee0;
 }
 
-[data-theme="dark"] .btn-toggle.active:hover {
+[data-theme="dark"] .btn.btn-toggle.active:hover {
   background: #4a4070;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from "react";
 import "./App.css";
-import { THIRTY_MINUTES, durations } from "./constants.ts";
+import { THIRTY_MINUTES, POMODORO_BREAK, durations } from "./constants.ts";
 import { getYouTubeTitle, NetworkError } from "./utils.ts";
 import { useSettings } from "./hooks/useSettings.ts";
 import { useBeeminder } from "./hooks/useBeeminder.ts";
@@ -18,6 +18,7 @@ const App: React.FC = () => {
   const [autoRenew, setAutoRenew] = useState(
     persistedTimer?.autoRenew ?? false,
   );
+  const [pomodoro, setPomodoro] = useState(persistedTimer?.pomodoro ?? false);
   const [youtubeTitle, setYoutubeTitle] = useState<string | null>(null);
 
   const { themePreference, setThemePreference } = useTheme();
@@ -88,6 +89,7 @@ const App: React.FC = () => {
     comment,
     volume,
     autoRenew,
+    pomodoro,
     onComplete,
     onFlush,
   });
@@ -195,14 +197,22 @@ const App: React.FC = () => {
           <div className="youtube-title">YouTube Title: {youtubeDisplay}</div>
         )}
 
-        <label className="auto-renew-label">
-          <input
-            type="checkbox"
-            checked={autoRenew}
-            onChange={(e) => setAutoRenew(e.target.checked)}
-          />
-          Auto-renew session
-        </label>
+        <div className="toggle-buttons">
+          <button
+            className={`btn btn-toggle ${autoRenew ? "active" : ""}`}
+            onClick={() => setAutoRenew((v) => !v)}
+            title="Auto-renew session"
+          >
+            🔁
+          </button>
+          <button
+            className={`btn btn-toggle ${pomodoro ? "active" : ""}`}
+            onClick={() => setPomodoro((v) => !v)}
+            title="Pomodoro mode (5-min breaks)"
+          >
+            🍅
+          </button>
+        </div>
 
         {timer.status === "idle" ? (
           <div className="duration-input-wrapper">
@@ -220,27 +230,31 @@ const App: React.FC = () => {
             <span className="duration-unit">minutes</span>
           </div>
         ) : (
-          <div className="progress-ring-wrapper">
-            <svg className="progress-ring" viewBox="0 0 120 120">
-              <circle className="progress-ring-bg" cx="60" cy="60" r="54" />
-              <circle
-                className="progress-ring-fill"
-                cx="60"
-                cy="60"
-                r="54"
-                strokeDasharray={2 * Math.PI * 54}
-                strokeDashoffset={
-                  2 *
-                  Math.PI *
-                  54 *
-                  (timer.remaining !== null
-                    ? timer.remaining / selectedDuration
-                    : 1)
-                }
-              />
-            </svg>
-            <div className="timer-display">{timer.displayTime}</div>
-          </div>
+          <>
+            {timer.isBreak && <div className="break-indicator">☕ Break</div>}
+            <div className="progress-ring-wrapper">
+              <svg className="progress-ring" viewBox="0 0 120 120">
+                <circle className="progress-ring-bg" cx="60" cy="60" r="54" />
+                <circle
+                  className="progress-ring-fill"
+                  cx="60"
+                  cy="60"
+                  r="54"
+                  strokeDasharray={2 * Math.PI * 54}
+                  strokeDashoffset={
+                    2 *
+                    Math.PI *
+                    54 *
+                    (timer.remaining !== null
+                      ? timer.remaining /
+                        (timer.isBreak ? POMODORO_BREAK : selectedDuration)
+                      : 1)
+                  }
+                />
+              </svg>
+              <div className="timer-display">{timer.displayTime}</div>
+            </div>
+          </>
         )}
 
         {timer.flushMessage && (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,6 @@ export const THEME_KEY = "beeminderTimerTheme";
 
 export const VOLUME_KEY = "beeminderTimerVolume";
 
+export const POMODORO_BREAK = 5 * 60; // 5 minutes in seconds
+
 export const durations = [5, 10, 15, 20, 30, 45, 60]; // minutes

--- a/src/hooks/useTimer.test.ts
+++ b/src/hooks/useTimer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useTimer } from "./useTimer.ts";
-import { TIMER_STATE_KEY } from "../constants.ts";
+import { TIMER_STATE_KEY, POMODORO_BREAK } from "../constants.ts";
 
 // Mock Audio
 vi.stubGlobal(
@@ -27,6 +27,7 @@ function makeOptions(overrides: Partial<Parameters<typeof useTimer>[0]> = {}) {
     comment: "",
     volume: 0.7,
     autoRenew: false,
+    pomodoro: false,
     onComplete: vi.fn().mockResolvedValue(undefined),
     onFlush: vi.fn().mockResolvedValue(undefined),
     ...overrides,
@@ -362,6 +363,133 @@ describe("useTimer", () => {
       expect(result.current.status).toBe("finished");
     });
     expect(localStorage.getItem(TIMER_STATE_KEY)).toBeNull();
+  });
+
+  it("pomodoro mode inserts a break after work session", async () => {
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const { result } = renderHook(() =>
+      useTimer(
+        makeOptions({
+          selectedDuration: 1,
+          onComplete,
+          autoRenew: true,
+          pomodoro: true,
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.startTimer();
+    });
+
+    // Advance past the deadline
+    vi.setSystemTime(now + 2000);
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    // onComplete should be called (work session logged)
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    // Should start a break session
+    await vi.waitFor(() => {
+      expect(result.current.status).toBe("running");
+    });
+    expect(result.current.isBreak).toBe(true);
+    expect(result.current.remaining).toBe(POMODORO_BREAK);
+  });
+
+  it("break session ends and starts new work session without posting", async () => {
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    // Start with a persisted break state
+    localStorage.setItem(
+      TIMER_STATE_KEY,
+      JSON.stringify({
+        status: "running",
+        remaining: 1,
+        deadline: now + 1000,
+        paused: false,
+        goalSlug: "test-goal",
+        selectedDuration: 1800,
+        comment: "",
+        autoRenew: true,
+        pomodoro: true,
+        isBreak: true,
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useTimer(
+        makeOptions({
+          selectedDuration: 1800,
+          onComplete,
+          autoRenew: true,
+          pomodoro: true,
+        }),
+      ),
+    );
+
+    expect(result.current.isBreak).toBe(true);
+    expect(result.current.status).toBe("running");
+
+    // Advance past the break deadline
+    vi.setSystemTime(now + 2000);
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    // Should start a new work session WITHOUT calling onComplete
+    await vi.waitFor(() => {
+      expect(result.current.remaining).toBe(1800);
+    });
+    expect(result.current.isBreak).toBe(false);
+    expect(result.current.status).toBe("running");
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("pomodoro without autoRenew finishes normally", async () => {
+    const onComplete = vi.fn().mockResolvedValue(undefined);
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const { result } = renderHook(() =>
+      useTimer(
+        makeOptions({
+          selectedDuration: 1,
+          onComplete,
+          autoRenew: false,
+          pomodoro: true,
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.startTimer();
+    });
+
+    // Advance past the deadline
+    vi.setSystemTime(now + 2000);
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    await vi.waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+
+    // Should finish normally (no break), since autoRenew is off
+    await vi.waitFor(() => {
+      expect(result.current.status).toBe("finished");
+    });
+    expect(result.current.isBreak).toBe(false);
   });
 
   it("updates document title when running", () => {

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import type { Status, StoredTimerState } from "../types.ts";
-import { TIMER_STATE_KEY } from "../constants.ts";
+import { TIMER_STATE_KEY, POMODORO_BREAK } from "../constants.ts";
 import { formatTime } from "../utils.ts";
 
 const ding = new Audio("notification.mp3");
@@ -37,6 +37,7 @@ type UseTimerOptions = {
   comment: string;
   volume: number;
   autoRenew: boolean;
+  pomodoro: boolean;
   onComplete: () => Promise<void>;
   onFlush: (elapsed: number) => Promise<void>;
 };
@@ -49,6 +50,7 @@ export function useTimer({
   comment,
   volume,
   autoRenew,
+  pomodoro,
   onComplete,
   onFlush,
 }: UseTimerOptions) {
@@ -62,6 +64,7 @@ export function useTimer({
   const [status, setStatus] = useState<Status>(persisted?.status ?? "idle");
   const [error, setError] = useState<string | null>(null);
   const [paused, setPaused] = useState(persisted?.paused ?? false);
+  const [isBreak, setIsBreak] = useState(persisted?.isBreak ?? false);
   const [flushMessage, setFlushMessage] = useState<string | null>(null);
 
   const running = status === "running";
@@ -108,6 +111,38 @@ export function useTimer({
     if (remaining !== 0 || status === "posting" || status === "finished")
       return;
 
+    const playDing = () => {
+      try {
+        ding.volume = volume;
+        ding.currentTime = 0;
+        void ding.play();
+      } catch {
+        // ignore
+      }
+    };
+
+    const startNewSession = (duration: number, breakMode: boolean) => {
+      const now = Date.now();
+      setStatus("running");
+      setRemaining(duration);
+      setDeadline(now + duration * 1000);
+      setPaused(false);
+      setIsBreak(breakMode);
+      const timerState: StoredTimerState = {
+        status: "running",
+        remaining: duration,
+        deadline: now + duration * 1000,
+        paused: false,
+        goalSlug,
+        selectedDuration,
+        comment,
+        autoRenew: true,
+        pomodoro,
+        isBreak: breakMode,
+      };
+      localStorage.setItem(TIMER_STATE_KEY, JSON.stringify(timerState));
+    };
+
     const doComplete = async () => {
       if (!username || !authToken || !goalSlug) {
         setStatus("error");
@@ -116,18 +151,18 @@ export function useTimer({
       }
 
       try {
+        // Break just ended — start new work session without posting
+        if (isBreak) {
+          playDing();
+          startNewSession(selectedDuration, false);
+          return;
+        }
+
         setStatus("posting");
         setError(null);
 
         await onComplete();
-
-        try {
-          ding.volume = volume;
-          ding.currentTime = 0;
-          void ding.play();
-        } catch {
-          // ignore
-        }
+        playDing();
 
         void showNotification("Session complete!", {
           body: `Logged session for ${goalSlug} to Beeminder.`,
@@ -136,23 +171,10 @@ export function useTimer({
           requireInteraction: false,
         });
 
-        if (autoRenew) {
-          const now = Date.now();
-          setStatus("running");
-          setRemaining(selectedDuration);
-          setDeadline(now + selectedDuration * 1000);
-          setPaused(false);
-          const timerState: StoredTimerState = {
-            status: "running",
-            remaining: selectedDuration,
-            deadline: now + selectedDuration * 1000,
-            paused: false,
-            goalSlug,
-            selectedDuration,
-            comment,
-            autoRenew: true,
-          };
-          localStorage.setItem(TIMER_STATE_KEY, JSON.stringify(timerState));
+        if (autoRenew && pomodoro) {
+          startNewSession(POMODORO_BREAK, true);
+        } else if (autoRenew) {
+          startNewSession(selectedDuration, false);
         } else {
           setStatus("finished");
           localStorage.removeItem(TIMER_STATE_KEY);
@@ -181,6 +203,7 @@ export function useTimer({
     setFlushMessage(null);
     setStatus("running");
     setPaused(false);
+    setIsBreak(false);
     setRemaining(selectedDuration);
     const now = Date.now();
     setDeadline(now + selectedDuration * 1000);
@@ -194,9 +217,19 @@ export function useTimer({
       selectedDuration,
       comment,
       autoRenew,
+      pomodoro,
+      isBreak: false,
     };
     localStorage.setItem(TIMER_STATE_KEY, JSON.stringify(timerState));
-  }, [goalSlug, username, authToken, selectedDuration, comment, autoRenew]);
+  }, [
+    goalSlug,
+    username,
+    authToken,
+    selectedDuration,
+    comment,
+    autoRenew,
+    pomodoro,
+  ]);
 
   const cancelTimer = useCallback(() => {
     if (
@@ -244,6 +277,8 @@ export function useTimer({
       selectedDuration,
       comment,
       autoRenew,
+      pomodoro,
+      isBreak,
     };
     localStorage.setItem(TIMER_STATE_KEY, JSON.stringify(timerState));
   }, [
@@ -255,6 +290,8 @@ export function useTimer({
     selectedDuration,
     comment,
     autoRenew,
+    pomodoro,
+    isBreak,
   ]);
 
   const flushTimer = useCallback(async () => {
@@ -361,6 +398,7 @@ export function useTimer({
     error,
     paused,
     running,
+    isBreak,
     flushMessage,
     displayTime,
     startTimer,

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ export type StoredTimerState = {
   selectedDuration: number;
   comment: string;
   autoRenew?: boolean;
+  pomodoro?: boolean;
+  isBreak?: boolean;
 };
 
 export type QueuedDatapoint = {


### PR DESCRIPTION
## Summary
- Replace the auto-renew checkbox with styled toggle buttons (🔁 auto-renew, 🍅 pomodoro)
- Toggle buttons use darker purple when inactive, lighter purple when active
- When both auto-renew and pomodoro are on, a 5-minute break is inserted between work sessions
- Break sessions don't post to Beeminder — only work sessions are logged
- Break indicator (☕ Break) shown during break sessions, progress ring uses correct break duration

## Test plan
- [x] `npm run build` — type-checks and builds
- [x] `npx vitest run` — all useTimer tests pass (21/21), including 3 new pomodoro tests
- [ ] Manual: toggle buttons render correctly, lighter when active, darker when off
- [ ] Manual: pomodoro mode inserts 5-min breaks between work sessions
- [ ] Manual: break sessions don't post to Beeminder

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)