### PR TITLE
Add keyboard shortcut hints and flush/cancel shortcuts

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -19,7 +19,7 @@ This file contains tasks to do. I will write these as I come up with ideas at wo
 - [ ] 5\. Notification sound volume control — currently hardcoded to 0.7; add a slider or at least a mute toggle
 - [x] 6\. Custom duration input — the editable timer display parses awkwardly (splits on `:`, ignores seconds); replace with a proper minutes input or a cleaner mm:ss parser
 - [ ] 7\. Toast/flash messages instead of inline status — flushMessage and error disappear only on next action; auto-dismiss after a few seconds
-- [ ] 8\. Keyboard shortcut hints — show that Space starts/pauses; consider adding shortcuts for flush (`f`) and cancel (`Esc`)
+- [x] 8\. Keyboard shortcut hints — show that Space starts/pauses; consider adding shortcuts for flush (`f`) and cancel (`Esc`)
 - [x] 9\. Mobile responsiveness — duration buttons wrap poorly on narrow screens; test and fix layout at small viewports
 
 ## Reliability

--- a/src/App.css
+++ b/src/App.css
@@ -417,6 +417,10 @@ select:focus {
   vertical-align: middle;
 }
 
+.btn-primary .shortcut-hint {
+  opacity: 0.85;
+}
+
 /* === Status Text === */
 .status-text {
   margin-top: 0.5rem;

--- a/src/App.css
+++ b/src/App.css
@@ -405,6 +405,18 @@ select:focus {
   transform: rotate(90deg);
 }
 
+/* === Shortcut Hints === */
+.shortcut-hint {
+  font-size: 0.65em;
+  font-weight: 500;
+  opacity: 0.6;
+  border: 1px solid currentcolor;
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+  margin-left: 0.3em;
+  vertical-align: middle;
+}
+
 /* === Status Text === */
 .status-text {
   margin-top: 0.5rem;

--- a/src/App.css
+++ b/src/App.css
@@ -419,6 +419,8 @@ select:focus {
 
 .btn-primary .shortcut-hint {
   opacity: 0.85;
+  color: #333;
+  border-color: #333;
 }
 
 /* === Status Text === */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -264,6 +264,7 @@ const App: React.FC = () => {
         {timer.status === "idle" && (
           <button className="btn btn-primary" onClick={timer.startTimer}>
             Start ⏱️
+            <span className="shortcut-hint">Space</span>
           </button>
         )}
 
@@ -271,12 +272,14 @@ const App: React.FC = () => {
           <div className="timer-actions">
             <button className="btn btn-secondary" onClick={timer.togglePause}>
               {timer.paused ? "▶️" : "⏸️"}
+              <span className="shortcut-hint">Space</span>
             </button>
             <button className="btn btn-secondary" onClick={timer.cancelTimer}>
-              ❌
+              ❌<span className="shortcut-hint">Esc</span>
             </button>
             <button className="btn btn-secondary" onClick={timer.flushTimer}>
               📤
+              <span className="shortcut-hint">F</span>
             </button>
           </div>
         )}

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -353,18 +353,19 @@ export function useTimer({
     onFlush,
   ]);
 
-  // Keyboard shortcut for space bar
+  // Keyboard shortcuts: Space (start/pause), f (flush), Escape (cancel)
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === " ") {
-        const activeElement = document.activeElement;
-        if (
-          activeElement instanceof HTMLInputElement ||
-          activeElement instanceof HTMLTextAreaElement
-        ) {
-          return;
-        }
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLInputElement ||
+        activeElement instanceof HTMLTextAreaElement ||
+        activeElement instanceof HTMLSelectElement
+      ) {
+        return;
+      }
 
+      if (event.key === " ") {
         event.preventDefault();
         if (!goalSlug || !username || !authToken || selectedDuration <= 0)
           return;
@@ -373,6 +374,12 @@ export function useTimer({
         } else if (status === "running" || paused) {
           togglePause();
         }
+      } else if (event.key === "f" && status === "running") {
+        event.preventDefault();
+        flushTimer();
+      } else if (event.key === "Escape" && status === "running") {
+        event.preventDefault();
+        cancelTimer();
       }
     };
 
@@ -387,6 +394,8 @@ export function useTimer({
     paused,
     startTimer,
     togglePause,
+    flushTimer,
+    cancelTimer,
   ]);
 
   const displayTime =


### PR DESCRIPTION
## Summary
- Added `f` keyboard shortcut to flush the timer while running
- Added `Escape` keyboard shortcut to cancel the timer while running
- Added shortcut hint badges (Space, Esc, F) on the Start and timer action buttons so users can discover shortcuts
- Fixed shortcut handler to also skip when a `<select>` element is focused

Closes #26

## Test plan
- [ ] Press `Space` when idle to start the timer — hint badge visible on Start button
- [ ] Press `Space` while running to pause/unpause — hint badge visible on pause button
- [ ] Press `f` while running to flush — hint badge visible on flush button
- [ ] Press `Escape` while running to cancel — hint badge visible on cancel button
- [ ] Shortcuts do not fire when typing in input fields or select dropdowns
- [ ] Hint badges look correct in both light and dark mode
- [ ] Hint badges display correctly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)