### PR TITLE
Reset timer on goal/duration change

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,6 +94,42 @@ const App: React.FC = () => {
     onFlush,
   });
 
+  const handleGoalChange = useCallback(
+    async (newGoal: string) => {
+      if (timer.running) {
+        if (
+          !window.confirm(
+            "Switch goal? Elapsed time will be logged to Beeminder.",
+          )
+        )
+          return;
+        await timer.flushTimer();
+      } else if (timer.status !== "idle") {
+        timer.resetAfterFinish();
+      }
+      beeminder.setGoalSlug(newGoal);
+    },
+    [timer, beeminder],
+  );
+
+  const handleDurationChange = useCallback(
+    async (durationSecs: number) => {
+      if (timer.running) {
+        if (
+          !window.confirm(
+            "Change duration? Elapsed time will be logged to Beeminder.",
+          )
+        )
+          return;
+        await timer.flushTimer();
+      } else if (timer.status !== "idle") {
+        timer.resetAfterFinish();
+      }
+      setSelectedDuration(durationSecs);
+    },
+    [timer, setSelectedDuration],
+  );
+
   // Fetch YouTube title if comment is a YouTube URL (debounced 200ms)
   useEffect(() => {
     const trimmed = comment.trim();
@@ -133,8 +169,8 @@ const App: React.FC = () => {
           <b> Goal </b>
           <select
             value={goalSlug || (goals.length > 0 ? goals[0].slug : "")}
-            onChange={(e) => beeminder.setGoalSlug(e.target.value)}
-            disabled={timer.running || goals.length === 0}
+            onChange={(e) => handleGoalChange(e.target.value)}
+            disabled={goals.length === 0}
           >
             {goals.length === 0 ? (
               <option value="">No goals loaded</option>
@@ -175,8 +211,7 @@ const App: React.FC = () => {
             <button
               key={duration}
               className="btn btn-secondary"
-              onClick={() => setSelectedDuration(duration * 60)}
-              disabled={timer.running}
+              onClick={() => handleDurationChange(duration * 60)}
             >
               {duration} min
             </button>


### PR DESCRIPTION
## Summary
- Goal selector and duration buttons are no longer disabled while the timer is running
- Changing goal or duration while timer is **finished/error/posting** auto-resets the timer
- Changing goal or duration while timer is **running** shows a confirmation prompt, then flushes elapsed time to Beeminder before applying the change

Closes #28

## Test plan
- [ ] Timer finished → click duration button → timer resets to that duration
- [ ] Timer finished → switch goal → timer resets, goal changes
- [ ] Timer running → click duration button → confirm prompt → flush + reset
- [ ] Timer running → switch goal → confirm prompt → flush + goal changes
- [ ] Timer running → confirm prompt → click "Cancel" → nothing changes
- [ ] Timer idle → switch goal or duration → works as before
- [ ] `npm run build` and `npm run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)